### PR TITLE
Add Adrian Twarog to Up and Coming

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@
 * [DevHoot](https://www.youtube.com/channel/UCV-F9TgeC_bSEdHH9qDfqXw)
 * [Nick Chapsas](https://www.youtube.com/user/ElfocrashDev)
 * [Romanian Coder](https://www.youtube.com/channel/UCgj2iw9vh5eX50YvKFZnpbw)
+* [Adrian Twarog](https://www.youtube.com/channel/UCvM5YYWwfLwpcQgbRr68JLQ/featured)
 
 ### Retired
 > These channels haven't uploaded in the last six months.


### PR DESCRIPTION
Hi everyone 😃,

I'd like to add Adrian Twarog's channel, since he is a recent youtuber that does mostly tutorials. Do you think the Tutorial section is more suitable than Up and Coming?

Thanks.