### PR TITLE
 "Code NCode" channel terminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@
 * [Errichto 2](https://www.youtube.com/channel/UC2D_ekI79trchAxgRq5mwpQ)
 * [Rachit Jain](https://www.youtube.com/channel/UC9fDC_eBh9e_bogw87DbGKQ)
 * [Algorithms Live](https://www.youtube.com/channel/UCBLr7ISa_YDy5qeATupf26w)
-* [Code NCode](https://www.youtube.com/channel/UC0zvY3yIBQTrSutsV-4yscQ)
 * [Go Code](https://www.youtube.com/channel/UCoEt3glB4rWSq5zEhSGhUWA)
 * [mycodeschool](https://www.youtube.com/channel/UClEEsT7DkdVO_fkrBw0OTrA)
 * [code_report](https://www.youtube.com/channel/UC1kBxkk2bcG78YBX7LMl9pQ)


### PR DESCRIPTION
Following link for [Code NCode](https://www.youtube.com/channel/UC0zvY3yIBQTrSutsV-4yscQ) returns "This account has been terminated because it is linked to an account that received multiple third-party claims of copyright infringement. 

As such, remove it from this list.